### PR TITLE
Add HTML content handling for Talking Kotlin summary.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,6 +117,7 @@ dependencies {
     implementation(libs.ktor.serialization.xml)
     implementation(libs.caffeine)
     implementation(libs.scrapeit)
+    implementation(libs.ksoup)
 
     testImplementation(kotlin("test"))
     testImplementation(libs.spring.boot.starter.test)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ graalvmNative = "0.10.6"
 caffeine = "3.2.0"
 scrapeit = "1.3.0-alpha.2"
 toolchainsResolver = "0.10.0"
+ksoup = "0.2.2"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
@@ -36,3 +37,4 @@ dgs-bom = { module = "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies"
 dgs-starter = { module = "com.netflix.graphql.dgs:dgs-starter"}
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
 scrapeit = { module = "it.skrape:skrapeit", version.ref = "scrapeit" }
+ksoup = { module = "com.fleeksoft.ksoup:ksoup", version.ref = "ksoup" }

--- a/src/main/kotlin/io/github/reactivecircus/kstreamlined/backend/datafetcher/mapper/HtmlContentParser.kt
+++ b/src/main/kotlin/io/github/reactivecircus/kstreamlined/backend/datafetcher/mapper/HtmlContentParser.kt
@@ -1,0 +1,8 @@
+package io.github.reactivecircus.kstreamlined.backend.datafetcher.mapper
+
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Document
+
+fun tryParseHtml(text: String): Document? = Ksoup.parse(text).let { doc ->
+    if (doc.body().childrenSize() == 0) null else doc
+}

--- a/src/main/kotlin/io/github/reactivecircus/kstreamlined/backend/datafetcher/mapper/TalkingKotlinEntryMapper.kt
+++ b/src/main/kotlin/io/github/reactivecircus/kstreamlined/backend/datafetcher/mapper/TalkingKotlinEntryMapper.kt
@@ -1,12 +1,18 @@
 package io.github.reactivecircus.kstreamlined.backend.datafetcher.mapper
 
 import io.github.reactivecircus.kstreamlined.backend.datasource.dto.TalkingKotlinItem
+import io.github.reactivecircus.kstreamlined.backend.schema.generated.types.ContentFormat
 import io.github.reactivecircus.kstreamlined.backend.schema.generated.types.TalkingKotlin
 import java.time.Duration
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 fun TalkingKotlinItem.toTalkingKotlinEntry(): TalkingKotlin {
+    val rawSummary = summary.sanitize()
+    val parsedDoc = tryParseHtml(rawSummary)
+    val summaryFormat = if (parsedDoc != null) ContentFormat.HTML else ContentFormat.TEXT
+    val summaryPlainText = parsedDoc?.text()
+
     return TalkingKotlin(
         id = guid,
         title = title,
@@ -16,7 +22,9 @@ fun TalkingKotlinItem.toTalkingKotlinEntry(): TalkingKotlin {
         contentUrl = link,
         thumbnailUrl = image.href,
         audioUrl = enclosure.url,
-        summary = summary.sanitize(),
+        summary = rawSummary,
+        summaryFormat = summaryFormat,
+        summaryPlainText = summaryPlainText,
         duration = duration.toFormattedDuration(),
     )
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,5 +5,5 @@ spring.graphql.schema.inspection.enabled=false
 
 ks.kotlin-blog-feed-url=https://blog.jetbrains.com/kotlin/feed/
 ks.kotlin-youtube-feed-url=https://www.youtube.com/feeds/videos.xml?channel_id=UCP7uiEZIqci43m22KDl0sNw
-ks.talking-kotlin-feed-url=https://feeds.soundcloud.com/users/soundcloud:users:280353173/sounds.rss
+ks.talking-kotlin-feed-url=https://anchor.fm/s/fdcf2fa8/podcast/rss
 ks.kotlin-weekly-feed-url=https://us12.campaign-archive.com/feed?u=f39692e245b94f7fb693b6d82&id=93b2272cb6

--- a/src/main/resources/schema/kstreamlined.graphqls
+++ b/src/main/resources/schema/kstreamlined.graphqls
@@ -88,6 +88,10 @@ type TalkingKotlin implements FeedEntry {
   thumbnailUrl: String!
   "Summary of the podcast."
   summary: String!
+  "Format of the summary content."
+  summaryFormat: ContentFormat!
+  "Plain text version of the summary. Available only if `summaryFormat` is `HTML`, `null` otherwise."
+  summaryPlainText: String
   "Duration of the podcast."
   duration: String!
 }
@@ -129,6 +133,13 @@ enum KotlinWeeklyIssueEntryGroup {
   VIDEOS
   "Libraries."
   LIBRARIES
+}
+
+enum ContentFormat {
+  "Plain text format."
+  TEXT
+  "HTML format."
+  HTML
 }
 
 "ISO 8601 instant."

--- a/src/test/kotlin/io/github/reactivecircus/kstreamlined/backend/datafetcher/FeedEntryDataFetcherTest.kt
+++ b/src/test/kotlin/io/github/reactivecircus/kstreamlined/backend/datafetcher/FeedEntryDataFetcherTest.kt
@@ -52,6 +52,8 @@ class FeedEntryDataFetcherTest {
                     audioUrl
                     thumbnailUrl
                     summary
+                    summaryFormat
+                    summaryPlainText
                     duration
                 }
                 ... on KotlinWeekly {
@@ -118,6 +120,8 @@ class FeedEntryDataFetcherTest {
         assert(context.read<String>("data.feedEntries[3].audioUrl") == dummyTalkingKotlinEntry.audioUrl)
         assert(context.read<String>("data.feedEntries[3].thumbnailUrl") == dummyTalkingKotlinEntry.thumbnailUrl)
         assert(context.read<String>("data.feedEntries[3].summary") == dummyTalkingKotlinEntry.summary)
+        assert(context.read<String>("data.feedEntries[3].summaryFormat") == dummyTalkingKotlinEntry.summaryFormat.name)
+        assert(context.read<String>("data.feedEntries[3].summaryPlainText") == dummyTalkingKotlinEntry.summaryPlainText)
         assert(context.read<String>("data.feedEntries[3].duration") == dummyTalkingKotlinEntry.duration)
     }
 

--- a/src/test/kotlin/io/github/reactivecircus/kstreamlined/backend/datafetcher/mapper/HtmlContentParserTest.kt
+++ b/src/test/kotlin/io/github/reactivecircus/kstreamlined/backend/datafetcher/mapper/HtmlContentParserTest.kt
@@ -1,0 +1,46 @@
+package io.github.reactivecircus.kstreamlined.backend.datafetcher.mapper
+
+import kotlin.test.Test
+
+class HtmlContentParserTest {
+
+    @Test
+    fun `tryParseHtml returns null for non-HTML content`() {
+        assert(tryParseHtml("This is plain text") == null)
+        assert(tryParseHtml("") == null)
+        assert(tryParseHtml("   \n  \t  ") == null)
+    }
+
+    @Test
+    fun `tryParseHtml returns Document for HTML content`() {
+        assert(tryParseHtml("<p>This is <b>HTML</b> content</p>") != null)
+        assert(
+            tryParseHtml(
+                """
+                    <p>This is a paragraph with a <a href="https://example.com">link</a> and a list:</p>
+                    <ul>
+                        <li>First item</li>
+                        <li>Second item with <b>bold</b> text</li>
+                    </ul>
+                """.trimIndent()
+            ) != null
+        )
+        assert(tryParseHtml("<p>This is &quot;quoted&quot; text with &amp; ampersand</p>") != null)
+    }
+
+    @Test
+    fun `tryParseHtml returns Document for HTML fragment`() {
+        assert(tryParseHtml("Plain text followed by <p>HTML</p>") != null)
+        assert(
+            tryParseHtml(
+                """
+                    Some plain text at the start
+                    <p>Followed by HTML content</p>
+                    <ul>
+                        <li>With a list</li>
+                    </ul>
+                """.trimIndent()
+            ) != null
+        )
+    }
+}

--- a/src/test/kotlin/io/github/reactivecircus/kstreamlined/backend/datafetcher/mapper/TalkingKotlinEntryMapperTest.kt
+++ b/src/test/kotlin/io/github/reactivecircus/kstreamlined/backend/datafetcher/mapper/TalkingKotlinEntryMapperTest.kt
@@ -1,6 +1,7 @@
 package io.github.reactivecircus.kstreamlined.backend.datafetcher.mapper
 
 import io.github.reactivecircus.kstreamlined.backend.datasource.dto.TalkingKotlinItem
+import io.github.reactivecircus.kstreamlined.backend.schema.generated.types.ContentFormat
 import io.github.reactivecircus.kstreamlined.backend.schema.generated.types.TalkingKotlin
 import java.time.Instant
 import kotlin.test.Test
@@ -8,7 +9,7 @@ import kotlin.test.Test
 class TalkingKotlinEntryMapperTest {
 
     @Test
-    fun `toTalkingKotlinEntry() converts TalkingKotlinItem to TalkingKotlin`() {
+    fun `toTalkingKotlinEntry() converts TalkingKotlinItem to TalkingKotlin when summary format is plain text`() {
         val expected = TalkingKotlin(
             id = "id",
             title = "Podcast title",
@@ -17,6 +18,8 @@ class TalkingKotlinEntryMapperTest {
             audioUrl = "audio-url",
             thumbnailUrl = "image-url",
             summary = "summary line 1 line 2 line 3",
+            summaryFormat = ContentFormat.TEXT,
+            summaryPlainText = null,
             duration = "43min.",
         )
         val actual = TalkingKotlinItem(
@@ -26,6 +29,34 @@ class TalkingKotlinEntryMapperTest {
             link = "url",
             duration = "00:43:14",
             summary = "summary line 1\n\n line 2 \r\n   line 3",
+            enclosure = TalkingKotlinItem.Enclosure(url = "audio-url"),
+            image = TalkingKotlinItem.Image(href = "image-url"),
+        ).toTalkingKotlinEntry()
+
+        assert(expected == actual)
+    }
+
+    @Test
+    fun `toTalkingKotlinEntry() converts TalkingKotlinItem to TalkingKotlin when summary format is HTML`() {
+        val expected = TalkingKotlin(
+            id = "id",
+            title = "Podcast title",
+            publishTime = Instant.parse("2022-11-22T16:30:09Z"),
+            contentUrl = "url",
+            audioUrl = "audio-url",
+            thumbnailUrl = "image-url",
+            summary = "<p>This is <b>HTML</b> content</p>",
+            summaryFormat = ContentFormat.HTML,
+            summaryPlainText = "This is HTML content",
+            duration = "43min.",
+        )
+        val actual = TalkingKotlinItem(
+            guid = "id",
+            title = "Podcast title",
+            pubDate = "Tue, 22 Nov 2022 16:30:09 +0000",
+            link = "url",
+            duration = "00:43:14",
+            summary = "<p>This is <b>HTML</b> content</p>",
             enclosure = TalkingKotlinItem.Enclosure(url = "audio-url"),
             image = TalkingKotlinItem.Image(href = "image-url"),
         ).toTalkingKotlinEntry()


### PR DESCRIPTION
Recent Talking Kotlin RSS feed entries started adding HTML content for `description`.

Added 2 fields on the `TalkingKotlin` type:
- `summaryFormat: ContentFormat!` - for deciding whether to render rich text in client
- `summaryPlainText: String` - for rendering summary in marquee text with no HTML tags or new lines